### PR TITLE
Change logo links to stream

### DIFF
--- a/archive/index.html
+++ b/archive/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -21,9 +21,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/donate/index.html
+++ b/donate/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -21,9 +21,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ thanks
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" style="border: 0; width: 100%;" />
   </a>
 

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -21,9 +21,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/participate/index.html
+++ b/participate/index.html
@@ -19,7 +19,7 @@
   <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <!--end google translate widget code-->
 
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -31,9 +31,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -32,9 +32,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/old/index.html
+++ b/schedule/old/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -22,9 +22,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stats/index.html
+++ b/stats/index.html
@@ -9,7 +9,7 @@
 </head>
 	
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -21,9 +21,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stream/2/index.html
+++ b/stream/2/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -23,9 +23,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stream/index.html
+++ b/stream/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <a href="http://news.kchungradio.org" class="no-hover">
+  <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 
@@ -23,9 +23,10 @@
 
   <div id="nav">
     <hr width="1038" color="white" />
+    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="https://news.kchungradio.org">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>


### PR DESCRIPTION
-  points the main kchung logo in index.html to /stream
-  points the kchung logo on all pages to /stream
-  moves "live stream" nav item to first position on all pages
-  puts a "news" item in the navbar of all pages (between archive and email links)

closes #4 