### PR TITLE
Make navigation match original site

### DIFF
--- a/archive/index.html
+++ b/archive/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/archive/index.html
+++ b/archive/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/donate/index.html
+++ b/donate/index.html
@@ -24,7 +24,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/donate/index.html
+++ b/donate/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/donate/index.html
+++ b/donate/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ thanks
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" style="border: 0; width: 100%;" />
   </a>
 </body>

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -24,7 +24,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/news/index.html
+++ b/news/index.html
@@ -11,7 +11,7 @@
   </style>
 </head>
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/news/index.html
+++ b/news/index.html
@@ -27,7 +27,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/news/index.html
+++ b/news/index.html
@@ -27,7 +27,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/participate/index.html
+++ b/participate/index.html
@@ -19,7 +19,7 @@
   <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   <!--end google translate widget code-->
 
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/participate/index.html
+++ b/participate/index.html
@@ -34,7 +34,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/participate/index.html
+++ b/participate/index.html
@@ -34,7 +34,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -35,7 +35,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -35,7 +35,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/old/index.html
+++ b/schedule/old/index.html
@@ -25,7 +25,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/schedule/old/index.html
+++ b/schedule/old/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/stats/index.html
+++ b/stats/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html> 
+<html>
 
 <head>
   <title>KCHUNG Radio 1630AM</title>
@@ -7,7 +7,7 @@
   <link rel="stylesheet" type="text/css" href="/css/style.css" />
   <meta property="og:image" content="/img/kchungforfacebook.jpg" />
 </head>
-	
+
 <body>
   <a href="/stream" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
@@ -24,7 +24,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
@@ -43,12 +43,12 @@
 
   <!--VosCast.com SHOUTcast Server Stats-->
   <script type="text/javascript" src="https://cdn.voscast.com/stats/display.js?key=5813540d2a3848320a3903b36067732a&stats=currentlisteners"></script> listeners right now.
-  <!--End SHOUTcast Server Stats--> 
+  <!--End SHOUTcast Server Stats-->
 
   <br />
   <br />
 
   <script src="/js/nospam.js"></script>
-</body> 
+</body>
 
 </html>

--- a/stats/index.html
+++ b/stats/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/stats/index.html
+++ b/stats/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stream/2/index.html
+++ b/stream/2/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/stream/2/index.html
+++ b/stream/2/index.html
@@ -26,7 +26,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stream/index.html
+++ b/stream/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <a href="/stream" class="no-hover">
+  <a href="/news" class="no-hover">
     <img src="/img/kchungblood.png" width="150" style="border: 0;" />
   </a>
 

--- a/stream/index.html
+++ b/stream/index.html
@@ -26,7 +26,7 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/posts">posts</a><span>&nbsp|&nbsp</span>
+    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>

--- a/stream/index.html
+++ b/stream/index.html
@@ -26,7 +26,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/news">news</a><span>&nbsp|&nbsp</span>
     <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
     <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>


### PR DESCRIPTION
For now I just swapped out all the links. I find it a bit confusing in the current site that the header image links to `news` instead of the landing page and that `news` isn't in the nav. But I'm happy to add that as well if it should mirror the existing site 1:1

Closes #24