### PR TITLE
Move replacement of search query characters to api

### DIFF
--- a/api/archive.js
+++ b/api/archive.js
@@ -5,7 +5,12 @@ module.exports = async function(req, res) {
 
   const { limit = 50, page = 0, search = '' } = req.query
 
-  console.log({ limit, page, search })
+  // console.log({ limit, page, search })
+
+  const _search = search
+    .trim()
+    .replace(/ /g, '_')
+    .replace(/\*/g, '%')
 
   const data = await db
     .query(
@@ -13,7 +18,7 @@ module.exports = async function(req, res) {
        WHERE path ILIKE $3
        ORDER BY date DESC
        LIMIT $1 OFFSET $2`,
-      [limit, page * limit, `%${search}%`]
+      [limit, page * limit, `%${_search}%`]
     )
     .then(data => data.rows)
     .then(rows =>

--- a/js/archive.js
+++ b/js/archive.js
@@ -50,11 +50,7 @@
 
     var query = '?page=' + page
     if (search) {
-      query += '&search='
-      query += search
-        .trim()
-        .replace(/ /g, '_')
-        .replace(/\*/g, '%')
+      query += '&search=' + search.trim()
     }
     var encodedURI = encodeURI(api + query)
 


### PR DESCRIPTION
It was a mistake to put the replace methods in the client code. With this change we can get wildcard benefits (#21) outside the website.