### PR TITLE
Change streams to point to Airtime

### DIFF
--- a/js/stream.js
+++ b/js/stream.js
@@ -1,0 +1,33 @@
+;(function() {
+  var liveInfoUrl = 'https://kchungradio.airtime.pro/api/live-info-v2'
+  var trackNameEl = document.getElementById('trackName')
+  var showNameEl = document.getElementById('showName')
+
+  // this runs after the DOM has loaded
+  $(function() {
+    $.get(liveInfoUrl, function(liveInfo) {
+      var trackNameText
+      var showNameText
+
+      if (
+        liveInfo &&
+        liveInfo.tracks &&
+        liveInfo.tracks.current &&
+        liveInfo.tracks.current.metadata
+      ) {
+        trackNameText = liveInfo.tracks.current.metadata.filepath
+      }
+
+      if (liveInfo && liveInfo.shows && liveInfo.shows.current) {
+        showNameText = liveInfo.shows.current.name
+      }
+
+      if (trackNameText && showNameText) {
+        trackNameEl.innerText = trackNameText
+        showNameEl.innerText = showNameText
+      } else {
+        showNameEl.innerText = 'kchung radio is offline...'
+      }
+    })
+  })
+})()

--- a/stream/index.html
+++ b/stream/index.html
@@ -55,16 +55,17 @@
 
       <div class="metadata">
         <div>now playing: </div>
-        <script type="text/javascript" src="https://cdn.voscast.com/stats/display.js?key=5813540d2a3848320a3903b36067732a&amp;stats=songtitle"></script>
-        <script type="text/javascript" src="https://cdn.voscast.com/stats/display.js?key=5813540d2a3848320a3903b36067732a&stats=servertitle"></script>
+        <!-- divs to display show metadata, used in /js/stream.js -->
+        <div id="trackName"></div>
+        <div id="showName"></div>
       </div>
 
       <br />
 
-      <p><a href="/stream2">click here for stream 2</a></p>
+      <p><a href="/stream2">not working? click here to try stream 2</a></p>
 
       <audio class="player" id="player" preload="none">
-        <source src="http://s9.voscast.com:7376/;&type=mp3" type="audio/mp3">
+        <source src="https://kchungradio.out.airtime.pro/kchungradio_a" type="audio/mp3">
         Your browser does not support the audio element.
       </audio>
     </div>
@@ -80,7 +81,6 @@
       data-custom-css="https://www.kchungradio.org/css/style.css"
       style="width:600px; height:400px;"
     ></div>
-    <script async src="https://tlk.io/embed.js"></script>
   </div>
 
   <br />
@@ -88,7 +88,9 @@
 
   <script src="https://code.jquery.com/jquery-1.9.0.min.js" integrity="sha256-f6DVw/U4x2+HjgEqw5BZf67Kq/5vudRZuRkljnbF344=" crossorigin="anonymous"></script>
   <script src="/js/nospam.js"></script>
+  <script src="/js/stream.js"></script>
   <script src="/js/play.js"></script>
+  <script src="https://tlk.io/embed.js"></script>
 </body>
 
 </html>

--- a/stream2/index.html
+++ b/stream2/index.html
@@ -55,8 +55,9 @@
 
       <div class="metadata">
         <div>now playing: </div>
-        <script type="text/javascript" src="https://cdn.voscast.com/stats/display.js?key=905c19fb7741145b136c112251646e4e&stats=songtitle"></script>
-        <script type="text/javascript" src="https://cdn.voscast.com/stats/display.js?key=905c19fb7741145b136c112251646e4e&stats=servertitle"></script>
+        <!-- divs to display show metadata, used in /js/stream.js -->
+        <div id="trackName"></div>
+        <div id="showName"></div>
       </div>
 
       <br />
@@ -64,7 +65,7 @@
       <p><a href="/stream">click here for stream 1</a></p>
 
       <audio class="player" id="player" preload="none">
-        <source src="http://s2.voscast.com:9208/;&type=mp3" type="audio/mp3">
+        <source src="https://kchungradio.out.airtime.pro/kchungradio_b" type="audio/mp3">
         Your browser does not support the audio element.
       </audio>
     </div>
@@ -80,7 +81,6 @@
       data-custom-css="https://www.kchungradio.org/css/style.css"
       style="width:600px; height:400px;"
     ></div>
-    <script async src="https://tlk.io/embed.js"></script>
   </div>
 
   <br />
@@ -88,7 +88,9 @@
 
   <script src="https://code.jquery.com/jquery-1.9.0.min.js" integrity="sha256-f6DVw/U4x2+HjgEqw5BZf67Kq/5vudRZuRkljnbF344=" crossorigin="anonymous"></script>
   <script src="/js/nospam.js"></script>
+  <script src="/js/stream.js"></script>
   <script src="/js/play.js"></script>
+  <script src="https://tlk.io/embed.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
We're moving our stream from Voscast to Airtime Pro. These changes update the stream url, fetches the show metadata, and displays it on the page. 

Note that Airtime only provides one unique stream (stream 1 and stream 2 are duplicates of each other and are used as fallbacks). With Airtime, anyone can stream during off-air times from anywhere, which obviates the need for the second stream as we were using it in the past as the mobile stream. If we want to use a separate stream for kchung.news, we'll have to create a separate account. 