### PR TITLE
Page changes needed for KCHUNG Public

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,16 +6,6 @@
   <link rel="icon" type="image/png" href="/img/favicon.ico" />
   <link rel="stylesheet" type="text/css" href="/css/style.css" />
   <meta property="og:image" content="/img/kchungforfacebook.jpg" />
-  <style>
-    iframe {
-      height: 1000px !important;
-      border: none;
-      width: 100%;
-      margin: 0px;
-      padding: 0px;
-      overflow: scroll;
-    }
-  </style>
 </head>
 
 <body>
@@ -27,7 +17,6 @@
   <br />
 
   <span>broadcasting on 1630 am, chinatown, los angeles</span>
-
   <br />
 
   <div id="nav">
@@ -51,7 +40,13 @@
   <br />
   <br />
 
-  <iframe src="https://kchungradio-schedule-calendar.now.sh"></iframe>
+  <div style="width:600px; padding:0; margin:0">
+    <h2>about KCHUNG</h2>
+      <p> KCHUNG Radio is an artist run co-operative and community radio station based in Chinatown, Los Angeles.</p>
+      <p>Since 2011, KCHUNG has pursued a distributed, affinity-based structure that promotes open participation and curatorial collaboration. Round-the-clock broadcasts and site-specific projects implemented by more than 200 contributing members reflect the diversity of the Los Angeles extensive music, arts, and social justice movements. KCHUNG Radio broadcasts cultural and political discourse, music, sound, art, and performance-based programs through low-powered and internet broadcasts, expanding on the history of radio as an empowering and creative medium.</p>
+      <p>KCHUNG Radio has collaborated with cultural organizations at all scales, including the UCLA Hammer Museum's Made in LA 2012 biennial, Ooga Booga, Thank You For Coming, Perform Chinatown, MOCA, Human Resources, LA Zine Fest, Night Gallery, The Smell, Pehrspace, and LACMA. KCHUNG Radio is a Creative Capital awardee.
+      </p>
+  </div>
 
   <script src="/js/nospam.js"></script>
 </body>

--- a/about/index.html
+++ b/about/index.html
@@ -22,12 +22,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>

--- a/about/index.html
+++ b/about/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/archive/index.html
+++ b/archive/index.html
@@ -22,12 +22,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>

--- a/archive/index.html
+++ b/archive/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/archive/index.html
+++ b/archive/index.html
@@ -22,17 +22,17 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
-    <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
+    <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>
     <a href="https://www.twitter.com/kchungradio">t</a><span>&nbsp</span>
-    <a href="https://www.instagram.com/kchungradio">i</a><span>&nbsp|&nbsp</span>
-    <a href="https://wiki.kchungradio.org">wiki</a><span>&nbsp|&nbsp</span>
-    <a href="https://kchung.bigcartel.com">store</a>
+    <a href="https://www.instagram.com/kchungradio">i</a>
     <br />
     <hr width="1038" color="white" />
   </div>

--- a/donate/index.html
+++ b/donate/index.html
@@ -22,17 +22,17 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
-    <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="https://kchung.bigcartel.com">store</a>
+    <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>
     <a href="https://www.twitter.com/kchungradio">t</a><span>&nbsp</span>
     <a href="https://www.instagram.com/kchungradio">i</a><span>&nbsp|&nbsp</span>
-    <a href="https://wiki.kchungradio.org">wiki</a><span>&nbsp|&nbsp</span>
-    <a href="https://kchung.bigcartel.com">store</a>
     <br />
     <hr width="1038" color="white" />
   </div>

--- a/donate/index.html
+++ b/donate/index.html
@@ -24,7 +24,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/donate/index.html
+++ b/donate/index.html
@@ -22,17 +22,17 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
-    <a href="https://kchung.bigcartel.com">store</a>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
+    <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>
     <a href="https://www.twitter.com/kchungradio">t</a><span>&nbsp</span>
-    <a href="https://www.instagram.com/kchungradio">i</a><span>&nbsp|&nbsp</span>
+    <a href="https://www.instagram.com/kchungradio">i</a>
     <br />
     <hr width="1038" color="white" />
   </div>

--- a/events/index.html
+++ b/events/index.html
@@ -22,12 +22,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>

--- a/events/index.html
+++ b/events/index.html
@@ -6,16 +6,6 @@
   <link rel="icon" type="image/png" href="/img/favicon.ico" />
   <link rel="stylesheet" type="text/css" href="/css/style.css" />
   <meta property="og:image" content="/img/kchungforfacebook.jpg" />
-  <style>
-    iframe {
-      height: 1000px !important;
-      border: none;
-      width: 100%;
-      margin: 0px;
-      padding: 0px;
-      overflow: scroll;
-    }
-  </style>
 </head>
 
 <body>
@@ -27,7 +17,6 @@
   <br />
 
   <span>broadcasting on 1630 am, chinatown, los angeles</span>
-
   <br />
 
   <div id="nav">
@@ -51,7 +40,9 @@
   <br />
   <br />
 
-  <iframe src="https://kchungradio-schedule-calendar.now.sh"></iframe>
+  <div style="width:600px; padding:0; margin:0">
+    <h2>Events</h2>
+  </div>
 
   <script src="/js/nospam.js"></script>
 </body>

--- a/participate/index.html
+++ b/participate/index.html
@@ -32,17 +32,17 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
-    <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
+    <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>
     <a href="https://www.twitter.com/kchungradio">t</a><span>&nbsp</span>
-    <a href="https://www.instagram.com/kchungradio">i</a><span>&nbsp|&nbsp</span>
-    <a href="https://wiki.kchungradio.org">wiki</a><span>&nbsp|&nbsp</span>
-    <a href="https://kchung.bigcartel.com">store</a>
+    <a href="https://www.instagram.com/kchungradio">i</a>
     <br />
     <hr width="1038" color="white" />
   </div>

--- a/participate/index.html
+++ b/participate/index.html
@@ -32,12 +32,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>

--- a/participate/index.html
+++ b/participate/index.html
@@ -34,7 +34,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -35,7 +35,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -33,12 +33,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>

--- a/stream/index.html
+++ b/stream/index.html
@@ -24,17 +24,17 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="javascript:noSpam('contact','kchungradio.org')" onfocus="this.blur();">e-mail</a><span>&nbsp|&nbsp</span>
-    <a href="/mailinglist">mailing list</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
+    <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>
     <a href="https://www.twitter.com/kchungradio">t</a><span>&nbsp</span>
-    <a href="https://www.instagram.com/kchungradio">i</a><span>&nbsp|&nbsp</span>
-    <a href="https://wiki.kchungradio.org">wiki</a><span>&nbsp|&nbsp</span>
-    <a href="https://kchung.bigcartel.com">store</a>
+    <a href="https://www.instagram.com/kchungradio">i</a>
     <br />
     <hr width="1038" color="white" />
   </div>
@@ -46,7 +46,7 @@
     <div class="kchung">
       <div class="play-buttons-container">
         <div class="play-button-container">
-          <span class="player-label">kchung</span>
+          <span class="player-label">kchung chinatown</span>
           <div class="play-pause">
             <a href="" class="play-button no-hover">
               <i class="fa fa-play big-icon" aria-hidden="true"></i>

--- a/stream/index.html
+++ b/stream/index.html
@@ -26,7 +26,6 @@
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
     <a href="/about">about</a><span>&nbsp|&nbsp</span>

--- a/stream/index.html
+++ b/stream/index.html
@@ -24,12 +24,12 @@
   <div id="nav">
     <hr width="1038" color="white" />
     <a href="/stream">live stream</a><span>&nbsp|&nbsp</span>
-    <a href="/about">about</a><span>&nbsp|&nbsp</span>
-    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/schedule">schedule</a><span>&nbsp|&nbsp</span>
     <a href="/archive">archive</a><span>&nbsp|&nbsp</span>
+    <a href="/events">events</a><span>&nbsp|&nbsp</span>
     <a href="/participate">participate</a><span>&nbsp|&nbsp</span>
     <a href="/donate">donate</a><span>&nbsp|&nbsp</span>
+    <a href="/about">about</a><span>&nbsp|&nbsp</span>
     <a href="https://kchung.bigcartel.com">store</a><span>&nbsp|&nbsp</span>
     <a href="https://www.moca.org/kchung-public">kchung public</a><span>&nbsp|&nbsp</span>
     <a href="https://www.facebook.com/kchungradio">f</a><span>&nbsp</span>


### PR DESCRIPTION
- Adds a `About` and `Events` tabs
- Removes the email and mailing list tabs
- Clarifies the stream names

Note: The events page is empty for now. I'm going to try to source the events from a notion page in a followup PR.
Note: the mailing list form will return in a more succinct version soon.