### PR TITLE
Use https s3 url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /.direnv/
 .next
 .vercel
+tsconfig.tsbuildinfo

--- a/pages/archive.js
+++ b/pages/archive.js
@@ -8,7 +8,8 @@ import 'intersection-observer' // polyfill for IE11
 import jsonFetcher from '../swr/jsonFetcher'
 import { slugify, unslugify } from '../lib/slugify'
 
-const s3 = 'http://archive.kchungradio.org/'
+const region = 'us-west-2'
+const s3 = `https://s3-${region}.amazonaws.com/archive.kchungradio.org/`
 
 function ArchivePage() {
   const router = useRouter()


### PR DESCRIPTION
Currently, when clicking a link to a show's mp3 file in Chrome, the user sees a full page message saying: "The connection to archive.kchungradio.org is not secure. You are seeing this warning because this site does not support HTTPS." This is confusing to users and may convince them not to listen.

![Screenshot 2024-08-09 at 10 13 50 AM](https://github.com/user-attachments/assets/b57b532a-7c13-449c-bb48-90575fb4170c)

This PR updates the url to point to the https version of the s3 bucket url, since the aws domain has its own SSL certificate.

Apparently it's not possible to apply a certificate to a bucket with a name that includes periods, which ours does. See the "Important" note at: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
